### PR TITLE
sepolicy: fixed denial for balti.migrate

### DIFF
--- a/sepolicy/vendor/untrusted_app_27.te
+++ b/sepolicy/vendor/untrusted_app_27.te
@@ -17,3 +17,4 @@ allow untrusted_app_27 hal_memtrack_default:binder { call };
 allow untrusted_app_27 proc_zoneinfo:file { read open getattr };
 allow untrusted_app_27 block_device:dir search;
 allow untrusted_app_27 proc:file { open read };
+allow untrusted_app_27 mnt_media_rw_file:dir { getattr };


### PR DESCRIPTION
This should fix denial:

W/balti.migrate( 6483): type=1400 audit(0.0:171): avc: denied { getattr } for comm=4173796E635461736B202332 path="/mnt/media_rw" dev="tmpfs" ino=2199 scontext=u:r:untrusted_app_27:s0:c512,c768 tcontext=u:object_r:mnt_media_rw_file:s0 tclass=dir permissive=0