### PR TITLE
sepolicy: fixed denial for com.facebook.mlite

### DIFF
--- a/sepolicy/vendor/untrusted_app_27.te
+++ b/sepolicy/vendor/untrusted_app_27.te
@@ -17,3 +17,4 @@ allow untrusted_app_27 hal_memtrack_default:binder { call };
 allow untrusted_app_27 proc_zoneinfo:file { read open getattr };
 allow untrusted_app_27 block_device:dir search;
 allow untrusted_app_27 proc:file { open read };
+allow untrusted_app_27 anr_data_file:dir { getattr };


### PR DESCRIPTION
This should fix:

W/com.facebook.mlite( 8101): type=1400 audit(0.0:17): avc: denied { getattr } for comm=4261636B67726F756E64207461736B path="/data/anr" dev="mmcblk0p79" ino=737281 scontext=u:r:untrusted_app_27:s0:c512,c768 tcontext=u:object_r:anr_data_file:s0 tclass=dir permissive=0