### PR TITLE
sepolicy: fixed denial for pool-4-thread-1

### DIFF
--- a/sepolicy/vendor/untrusted_app.te
+++ b/sepolicy/vendor/untrusted_app.te
@@ -13,4 +13,4 @@ allow untrusted_app sysfs_net:dir search;
 allow untrusted_app sysfs:dir { read };
 allow untrusted_app proc_version:file { getattr read };
 allow untrusted_app proc_stat:file { getattr };
-allow untrusted_app sysfs_kgsl:file { getattr read };
+allow untrusted_app sysfs_kgsl:file { getattr read open };


### PR DESCRIPTION
This should fix denial for:

W/pool-4-thread-1( 8175): type=1400 audit(0.0:19): avc: denied { open } for path="/sys/devices/soc/5000000.qcom,kgsl-3d0/devfreq/5000000.qcom,kgsl-3d0/governor" dev="sysfs" ino=30732 scontext=u:r:untrusted_app:s0:c233,c256,c512,c768 tcontext=u:object_r:sysfs_kgsl:s0 tclass=file permissive=0