### PR TITLE
sepolicy: fixed denial for for interface=android.hardware.memtrack::I…

### DIFF
--- a/sepolicy/vendor/untrusted_app.te
+++ b/sepolicy/vendor/untrusted_app.te
@@ -14,3 +14,4 @@ allow untrusted_app sysfs:dir { read };
 allow untrusted_app proc_version:file { getattr read };
 allow untrusted_app proc_stat:file { getattr };
 allow untrusted_app sysfs_kgsl:file { getattr read };
+allow untrusted_app hal_memtrack_hwservice:hwservice_manager { find };


### PR DESCRIPTION
…Memtrack

This should fix denial for:

E/SELinux (  599): avc:  denied  { find } for interface=android.hardware.memtrack::IMemtrack sid=u:r:untrusted_app:s0:c245,c256,c512,c768 pid=6207 scontext=u:r:untrusted_app:s0:c245,c256,c512,c768 tcontext=u:object_r:hal_memtrack_hwservice:s0 tclass=hwservice_manager permissive=0